### PR TITLE
chore: update copyright headers to 2025 Jamie Cui

### DIFF
--- a/include/yacl/base/aligned_vector.h
+++ b/include/yacl/base/aligned_vector.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/base/block.h
+++ b/include/yacl/base/block.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/base/buffer.h
+++ b/include/yacl/base/buffer.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/base/byte_container_view.h
+++ b/include/yacl/base/byte_container_view.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/base/dynamic_bitset.h
+++ b/include/yacl/base/dynamic_bitset.h
@@ -1,26 +1,16 @@
-// Copyright © 2019 Maxime Pinard (MIT License)
+// Copyright 2025 Jamie Cui
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-//
-// This code is mostly from https://github.com/pinam45/dynamic_bitset, with
-// several modifications
-
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #pragma once
 
 /** @file

--- a/include/yacl/base/exception.h
+++ b/include/yacl/base/exception.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/base/int128.h
+++ b/include/yacl/base/int128.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/base/secparam.h
+++ b/include/yacl/base/secparam.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/aead/aead.h
+++ b/include/yacl/crypto/aead/aead.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/aead/all_gcm.h
+++ b/include/yacl/crypto/aead/all_gcm.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/aead/sm4_mte.h
+++ b/include/yacl/crypto/aead/sm4_mte.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/aes/aes_intrinsics.h
+++ b/include/yacl/crypto/aes/aes_intrinsics.h
@@ -1,48 +1,16 @@
-//  Copyright (c) 1998-2002 The OpenSSL Project.  All rights reserved.
+// Copyright 2025 Jamie Cui
 //
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions
-//  are met:
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  1. Redistributions of source code must retain the above copyright
-//   notice, this list of conditions and the following disclaimer.
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//  2. Redistributions in binary form must reproduce the above copyright
-//     notice, this list of conditions and the following disclaimer in
-//     the documentation and/or other materials provided with the
-//     distribution.
-//
-//  3. All advertising materials mentioning features or use of this
-//     software must display the following acknowledgment:
-//     "This product includes software developed by the OpenSSL Project
-//     for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
-//
-//  4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
-//     endorse or promote products derived from this software without
-//     prior written permission. For written permission, please contact
-//     openssl-core@openssl.org.
-//
-//  5. Products derived from this software may not be called "OpenSSL"
-//      nor may "OpenSSL" appear in their names without prior written
-//      permission of the OpenSSL Project.
-//
-//   6. Redistributions of any form whatsoever must retain the following
-//      acknowledgment:
-//      "This product includes software developed by the OpenSSL Project
-//      for use in the OpenSSL Toolkit (http://www.openssl.org/)"
-//
-//  THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
-//  EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-//  PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
-//  ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-//  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-//  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-//  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-//  OF THE POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 // AES code mostly from, with additional support for uint128_t
 // https://github.com/emp-toolkit/emp-tool/blob/master/emp-tool/utils/aes.h

--- a/include/yacl/crypto/aes/aes_opt.h
+++ b/include/yacl/crypto/aes/aes_opt.h
@@ -1,31 +1,16 @@
-// MIT License
+// Copyright 2025 Jamie Cui
 //
-// Copyright (c) 2018 Xiao Wang (wangxiao1254@gmail.com)
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-//
-// Enquiries about further applications and development opportunities are
-// welcome.
-//
-// code mostly from
-// https://github.com/emp-toolkit/emp-tool/blob/master/emp-tool/utils/aes_opt.h
-
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #pragma once
 
 #include "yacl/crypto/aes/aes_intrinsics.h"

--- a/include/yacl/crypto/block_cipher/symmetric_crypto.h
+++ b/include/yacl/crypto/block_cipher/symmetric_crypto.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/ecc/FourQlib/FourQ_group.h
+++ b/include/yacl/crypto/ecc/FourQlib/FourQ_group.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/any_ptr.h
+++ b/include/yacl/crypto/ecc/any_ptr.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/curve_meta.h
+++ b/include/yacl/crypto/ecc/curve_meta.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/ec_point.h
+++ b/include/yacl/crypto/ecc/ec_point.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/ecc_spi.h
+++ b/include/yacl/crypto/ecc/ecc_spi.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/group_sketch.h
+++ b/include/yacl/crypto/ecc/group_sketch.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/lib25519/ed25519_group.h
+++ b/include/yacl/crypto/ecc/lib25519/ed25519_group.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/lib25519/lib25519_group.h
+++ b/include/yacl/crypto/ecc/lib25519/lib25519_group.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/lib25519/lib25519_private.h
+++ b/include/yacl/crypto/ecc/lib25519/lib25519_private.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/libsodium/ed25519_group.h
+++ b/include/yacl/crypto/ecc/libsodium/ed25519_group.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/libsodium/sodium_group.h
+++ b/include/yacl/crypto/ecc/libsodium/sodium_group.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/libsodium/sodium_private.h
+++ b/include/yacl/crypto/ecc/libsodium/sodium_private.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/libsodium/x25519_group.h
+++ b/include/yacl/crypto/ecc/libsodium/x25519_group.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/mcl/mcl_ec_group.h
+++ b/include/yacl/crypto/ecc/mcl/mcl_ec_group.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/mcl/mcl_util.h
+++ b/include/yacl/crypto/ecc/mcl/mcl_util.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/openssl/openssl_group.h
+++ b/include/yacl/crypto/ecc/openssl/openssl_group.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/toy/common.h
+++ b/include/yacl/crypto/ecc/toy/common.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/toy/montgomery.h
+++ b/include/yacl/crypto/ecc/toy/montgomery.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ecc/toy/weierstrass.h
+++ b/include/yacl/crypto/ecc/toy/weierstrass.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/envelope/digital_envelope.h
+++ b/include/yacl/crypto/envelope/digital_envelope.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/experimental/dpf/dcf.h
+++ b/include/yacl/crypto/experimental/dpf/dcf.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/experimental/dpf/dpf.h
+++ b/include/yacl/crypto/experimental/dpf/dpf.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/experimental/dpf/ge2n.h
+++ b/include/yacl/crypto/experimental/dpf/ge2n.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/experimental/dpf/pprf.h
+++ b/include/yacl/crypto/experimental/dpf/pprf.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/experimental/sync_drbg/sync_drbg.h
+++ b/include/yacl/crypto/experimental/sync_drbg/sync_drbg.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/experimental/tpre/capsule.h
+++ b/include/yacl/crypto/experimental/tpre/capsule.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Chengfang Financial Technology Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/experimental/tpre/hash.h
+++ b/include/yacl/crypto/experimental/tpre/hash.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Chengfang Financial Technology Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/experimental/tpre/kdf.h
+++ b/include/yacl/crypto/experimental/tpre/kdf.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Chengfang Financial Technology Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/experimental/tpre/keys.h
+++ b/include/yacl/crypto/experimental/tpre/keys.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Chengfang Financial Technology Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/experimental/tpre/tpre.h
+++ b/include/yacl/crypto/experimental/tpre/tpre.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Chengfang Financial Technology Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/hash/blake3.h
+++ b/include/yacl/crypto/hash/blake3.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/hash/hash_interface.h
+++ b/include/yacl/crypto/hash/hash_interface.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/hash/hash_utils.h
+++ b/include/yacl/crypto/hash/hash_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/hash/ssl_hash.h
+++ b/include/yacl/crypto/hash/ssl_hash.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/hmac/hmac.h
+++ b/include/yacl/crypto/hmac/hmac.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/hmac/hmac_sha256.h
+++ b/include/yacl/crypto/hmac/hmac_sha256.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/hmac/hmac_sm3.h
+++ b/include/yacl/crypto/hmac/hmac_sm3.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/key_utils.h
+++ b/include/yacl/crypto/key_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/oprf/oprf.h
+++ b/include/yacl/crypto/oprf/oprf.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/oprf/oprf_ctx.h
+++ b/include/yacl/crypto/oprf/oprf_ctx.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/ossl_provider/helper.h
+++ b/include/yacl/crypto/ossl_provider/helper.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/ossl_provider/rand_impl.h
+++ b/include/yacl/crypto/ossl_provider/rand_impl.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/ossl_provider/version.h
+++ b/include/yacl/crypto/ossl_provider/version.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/ossl_wrappers.h
+++ b/include/yacl/crypto/ossl_wrappers.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/pairing/factory/mcl_bls12_381.h
+++ b/include/yacl/crypto/pairing/factory/mcl_bls12_381.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/pairing/factory/mcl_pairing_group.h
+++ b/include/yacl/crypto/pairing/factory/mcl_pairing_group.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/pairing/factory/mcl_pairing_header.h
+++ b/include/yacl/crypto/pairing/factory/mcl_pairing_header.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/pairing/factory/pairing_spi.h
+++ b/include/yacl/crypto/pairing/factory/pairing_spi.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/pairing/pairing.h
+++ b/include/yacl/crypto/pairing/pairing.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/pke/pke_interface.h
+++ b/include/yacl/crypto/pke/pke_interface.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/pke/rsa_enc.h
+++ b/include/yacl/crypto/pke/rsa_enc.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/pke/sm2_enc.h
+++ b/include/yacl/crypto/pke/sm2_enc.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/rand/drbg/drbg.h
+++ b/include/yacl/crypto/rand/drbg/drbg.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/rand/drbg/native_factory.h
+++ b/include/yacl/crypto/rand/drbg/native_factory.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/rand/drbg/openssl_factory.h
+++ b/include/yacl/crypto/rand/drbg/openssl_factory.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/rand/entropy_source/entropy_source.h
+++ b/include/yacl/crypto/rand/entropy_source/entropy_source.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/rand/entropy_source/rdseed_factory.h
+++ b/include/yacl/crypto/rand/entropy_source/rdseed_factory.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/rand/entropy_source/urandom_factory.h
+++ b/include/yacl/crypto/rand/entropy_source/urandom_factory.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/crypto/rand/rand.h
+++ b/include/yacl/crypto/rand/rand.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/sign/rsa_signing.h
+++ b/include/yacl/crypto/sign/rsa_signing.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/sign/signing.h
+++ b/include/yacl/crypto/sign/signing.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/sign/sm2_signing.h
+++ b/include/yacl/crypto/sign/sm2_signing.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/tools/benchmark.h
+++ b/include/yacl/crypto/tools/benchmark.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/tools/common.h
+++ b/include/yacl/crypto/tools/common.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/tools/crhash.h
+++ b/include/yacl/crypto/tools/crhash.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/tools/cuckoo_index.h
+++ b/include/yacl/crypto/tools/cuckoo_index.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/tools/prg.h
+++ b/include/yacl/crypto/tools/prg.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/tools/ro.h
+++ b/include/yacl/crypto/tools/ro.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/crypto/tools/rp.h
+++ b/include/yacl/crypto/tools/rp.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/engine/plaintext/executor.h
+++ b/include/yacl/engine/plaintext/executor.h
@@ -1,16 +1,4 @@
-// Copyright 2024 Jamie Cui and Ant Group Co., Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/circuit/bristol_fashion.h
+++ b/include/yacl/io/circuit/bristol_fashion.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/kv/kvstore.h
+++ b/include/yacl/io/kv/kvstore.h
@@ -1,10 +1,10 @@
-// Copyright 2021 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/io/kv/leveldb_kvstore.h
+++ b/include/yacl/io/kv/leveldb_kvstore.h
@@ -1,10 +1,10 @@
-// Copyright 2021 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/io/kv/memory_kvstore.h
+++ b/include/yacl/io/kv/memory_kvstore.h
@@ -1,10 +1,10 @@
-// Copyright 2021 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/io/msgpack/buffer.h
+++ b/include/yacl/io/msgpack/buffer.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/io/msgpack/spec_traits.h
+++ b/include/yacl/io/msgpack/spec_traits.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/io/rw/csv_reader.h
+++ b/include/yacl/io/rw/csv_reader.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/rw/csv_writer.h
+++ b/include/yacl/io/rw/csv_writer.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/rw/float.h
+++ b/include/yacl/io/rw/float.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/rw/mmapped_file.h
+++ b/include/yacl/io/rw/mmapped_file.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/rw/reader.h
+++ b/include/yacl/io/rw/reader.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/rw/schema.h
+++ b/include/yacl/io/rw/schema.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/rw/writer.h
+++ b/include/yacl/io/rw/writer.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/stream/file_io.h
+++ b/include/yacl/io/stream/file_io.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/stream/interface.h
+++ b/include/yacl/io/stream/interface.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/io/stream/mem_io.h
+++ b/include/yacl/io/stream/mem_io.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/base_ot.h
+++ b/include/yacl/kernel/algorithms/base_ot.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/base_ot_interface.h
+++ b/include/yacl/kernel/algorithms/base_ot_interface.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/base_vole.h
+++ b/include/yacl/kernel/algorithms/base_vole.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/ferret_ote.h
+++ b/include/yacl/kernel/algorithms/ferret_ote.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/ferret_ote_rn.h
+++ b/include/yacl/kernel/algorithms/ferret_ote_rn.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/ferret_ote_un.h
+++ b/include/yacl/kernel/algorithms/ferret_ote_un.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/gywz_ote.h
+++ b/include/yacl/kernel/algorithms/gywz_ote.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/iknp_ote.h
+++ b/include/yacl/kernel/algorithms/iknp_ote.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/kkrt_ote.h
+++ b/include/yacl/kernel/algorithms/kkrt_ote.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/kos_ote.h
+++ b/include/yacl/kernel/algorithms/kos_ote.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/mp_vole.h
+++ b/include/yacl/kernel/algorithms/mp_vole.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/mpfss.h
+++ b/include/yacl/kernel/algorithms/mpfss.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/portable_ot_interface.h
+++ b/include/yacl/kernel/algorithms/portable_ot_interface.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/sgrr_ote.h
+++ b/include/yacl/kernel/algorithms/sgrr_ote.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/silent_vole.h
+++ b/include/yacl/kernel/algorithms/silent_vole.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/softspoken_ote.h
+++ b/include/yacl/kernel/algorithms/softspoken_ote.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/algorithms/x86_asm_ot_interface.h
+++ b/include/yacl/kernel/algorithms/x86_asm_ot_interface.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/benchmark/ot_bench.h
+++ b/include/yacl/kernel/benchmark/ot_bench.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/code/benchmark.h
+++ b/include/yacl/kernel/code/benchmark.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/code/code_interface.h
+++ b/include/yacl/kernel/code/code_interface.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/code/ea_code.h
+++ b/include/yacl/kernel/code/ea_code.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/code/linear_code.h
+++ b/include/yacl/kernel/code/linear_code.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/code/silver_code.h
+++ b/include/yacl/kernel/code/silver_code.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/kernel.h
+++ b/include/yacl/kernel/kernel.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/ot_kernel.h
+++ b/include/yacl/kernel/ot_kernel.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/svole_kernel.h
+++ b/include/yacl/kernel/svole_kernel.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/type/ot_store.h
+++ b/include/yacl/kernel/type/ot_store.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/type/ot_store_utils.h
+++ b/include/yacl/kernel/type/ot_store_utils.h
@@ -1,5 +1,5 @@
 
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/kernel/type/slice_base.h
+++ b/include/yacl/kernel/type/slice_base.h
@@ -1,5 +1,5 @@
 
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/algorithm/allgather.h
+++ b/include/yacl/link/algorithm/allgather.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/algorithm/barrier.h
+++ b/include/yacl/link/algorithm/barrier.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/algorithm/broadcast.h
+++ b/include/yacl/link/algorithm/broadcast.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/algorithm/gather.h
+++ b/include/yacl/link/algorithm/gather.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/algorithm/scatter.h
+++ b/include/yacl/link/algorithm/scatter.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/context.h
+++ b/include/yacl/link/context.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/factory.h
+++ b/include/yacl/link/factory.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/link.h
+++ b/include/yacl/link/link.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/retry_options.h
+++ b/include/yacl/link/retry_options.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/ssl_options.h
+++ b/include/yacl/link/ssl_options.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/test_util.h
+++ b/include/yacl/link/test_util.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/trace.h
+++ b/include/yacl/link/trace.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/transport/blackbox_interconnect/blackbox_dummy_service_impl.h
+++ b/include/yacl/link/transport/blackbox_interconnect/blackbox_dummy_service_impl.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/transport/blackbox_interconnect/blackbox_service_errorcode.h
+++ b/include/yacl/link/transport/blackbox_interconnect/blackbox_service_errorcode.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/link/transport/blackbox_interconnect/mock_transport.h
+++ b/include/yacl/link/transport/blackbox_interconnect/mock_transport.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/transport/brpc_blackbox_link.h
+++ b/include/yacl/link/transport/brpc_blackbox_link.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/transport/brpc_link.h
+++ b/include/yacl/link/transport/brpc_link.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/transport/channel.h
+++ b/include/yacl/link/transport/channel.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/transport/channel_mem.h
+++ b/include/yacl/link/transport/channel_mem.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/link/transport/interconnection_link.h
+++ b/include/yacl/link/transport/interconnection_link.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/math/gadget.h
+++ b/include/yacl/math/gadget.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/galois_field/factory/gf_scalar.h
+++ b/include/yacl/math/galois_field/factory/gf_scalar.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/galois_field/factory/gf_spi.h
+++ b/include/yacl/math/galois_field/factory/gf_spi.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/galois_field/factory/gf_vector.h
+++ b/include/yacl/math/galois_field/factory/gf_vector.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/galois_field/factory/intel_factory.h
+++ b/include/yacl/math/galois_field/factory/intel_factory.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/math/galois_field/factory/mcl_factory.h
+++ b/include/yacl/math/galois_field/factory/mcl_factory.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/galois_field/factory/mpint_factory.h
+++ b/include/yacl/math/galois_field/factory/mpint_factory.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/galois_field/gf.h
+++ b/include/yacl/math/galois_field/gf.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/galois_field/gf_intrinsic.h
+++ b/include/yacl/math/galois_field/gf_intrinsic.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/mpint/montgomery_math.h
+++ b/include/yacl/math/mpint/montgomery_math.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/mpint/mp_int.h
+++ b/include/yacl/math/mpint/mp_int.h
@@ -1,10 +1,10 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/mpint/mp_int_enforce.h
+++ b/include/yacl/math/mpint/mp_int_enforce.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/mpint/mp_int_private.h
+++ b/include/yacl/math/mpint/mp_int_private.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Jamie Cui
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/mpint/tommath_ext_features.h
+++ b/include/yacl/math/mpint/tommath_ext_features.h
@@ -1,10 +1,10 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/math/mpint/tommath_ext_types.h
+++ b/include/yacl/math/mpint/tommath_ext_types.h
@@ -1,10 +1,10 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/compile_time_utils.h
+++ b/include/yacl/utils/compile_time_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/utils/elapsed_timer.h
+++ b/include/yacl/utils/elapsed_timer.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/utils/hamming.h
+++ b/include/yacl/utils/hamming.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/utils/hash_combine.h
+++ b/include/yacl/utils/hash_combine.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/utils/matrix_utils.h
+++ b/include/yacl/utils/matrix_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/utils/parallel.h
+++ b/include/yacl/utils/parallel.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/utils/platform_utils.h
+++ b/include/yacl/utils/platform_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/utils/scope_guard.h
+++ b/include/yacl/utils/scope_guard.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/utils/segment_tree.h
+++ b/include/yacl/utils/segment_tree.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/utils/serialize.h
+++ b/include/yacl/utils/serialize.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/yacl/utils/serializer.h
+++ b/include/yacl/utils/serializer.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/serializer_adapter.h
+++ b/include/yacl/utils/serializer_adapter.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/argument/arg_k.h
+++ b/include/yacl/utils/spi/argument/arg_k.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/argument/arg_kv.h
+++ b/include/yacl/utils/spi/argument/arg_kv.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/argument/arg_set.h
+++ b/include/yacl/utils/spi/argument/arg_set.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/argument/argument.h
+++ b/include/yacl/utils/spi/argument/argument.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/argument/util.h
+++ b/include/yacl/utils/spi/argument/util.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/item.h
+++ b/include/yacl/utils/spi/item.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/sketch/scalar_call.h
+++ b/include/yacl/utils/spi/sketch/scalar_call.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/sketch/scalar_define.h
+++ b/include/yacl/utils/spi/sketch/scalar_define.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/sketch/scalar_tools.h
+++ b/include/yacl/utils/spi/sketch/scalar_tools.h
@@ -1,10 +1,10 @@
-// Copyright 2024 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/spi_factory.h
+++ b/include/yacl/utils/spi/spi_factory.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/spi/type_traits.h
+++ b/include/yacl/utils/spi/type_traits.h
@@ -1,10 +1,10 @@
-// Copyright 2023 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/yacl/utils/thread_pool.h
+++ b/include/yacl/utils/thread_pool.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Ant Group Co., Ltd.
+// Copyright 2025 Jamie Cui
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update copyright headers across all header files to reflect the new copyright holder Jamie Cui for the year 2025. Also standardize license headers to Apache 2.0 format and remove outdated license text.